### PR TITLE
baltimore-ravens updates @ xpathSApply

### DIFF
--- a/03_GettingData/01_07_readingXML/index.md
+++ b/03_GettingData/01_07_readingXML/index.md
@@ -226,8 +226,8 @@ xpathSApply(rootNode,"//price",xmlValue)
 ```r
 fileUrl <- "http://espn.go.com/nfl/team/_/name/bal/baltimore-ravens"
 doc <- htmlTreeParse(fileUrl,useInternal=TRUE)
-scores <- xpathSApply(doc,"//li[@class='score']",xmlValue)
-teams <- xpathSApply(doc,"//li[@class='team-name']",xmlValue)
+scores <- xpathSApply(doc,"//div[@class='score']",xmlValue)
+teams <- xpathSApply(doc,"//div[@class='game-info']",xmlValue)
 scores
 ```
 


### PR DESCRIPTION
The original commands only showed an empty list for "scores" and "teams".
I fixed it.